### PR TITLE
chore: create .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="mysql://user:password@host:port/db"
+NEXTAUTH_SECRET = "your-secret-key"
+SUPABASE_SERVICE_ROLE_KEY = "your-supabase-service-role-key"
+SUPABASE_URL = "your-supabase-url"

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel


### PR DESCRIPTION
This pull request adds a new `.env.example` file to provide a template for environment variables required by the application. The file includes placeholders for database connection details and authentication secrets.

Key changes:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R10): Added environment variable placeholders for `DATABASE_URL`, `NEXTAUTH_SECRET`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_URL`, along with comments explaining their purpose and links to relevant documentation.