### PR TITLE
feat: add secret checks to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-capability.yml
+++ b/.github/workflows/build-capability.yml
@@ -26,6 +26,21 @@ jobs:
         with:
           node-version: 20
 
+      - name: Check for required secrets
+        run: |
+          missing_secrets=0
+          if [ -z "${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" ]; then
+            echo "Error: Secret SUPABASE_SERVICE_ROLE_KEY is not set."
+            missing_secrets=1
+          fi
+          if [ -z "${{ secrets.SUPABASE_URL }}" ]; then
+            echo "Error: Secret SUPABASE_URL is not set."
+            missing_secrets=1
+          fi
+          if [ $missing_secrets -eq 1 ]; then
+            exit 1
+          fi
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
This pull request introduces a new step in the GitHub Actions workflow to ensure required secrets are set before proceeding with the build process.

### Workflow enhancements:
* [`.github/workflows/build-capability.yml`](diffhunk://#diff-fd569839c16f451253536f994948901bd6507edd54b26a0237249899cf7b2502R29-R43): Added a step named "Check for required secrets" to validate the presence of `SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_URL` secrets. If either secret is missing, the workflow will terminate with an error.