### PR TITLE
chore: resolve ci environment variable

### DIFF
--- a/.github/workflows/build-capability.yml
+++ b/.github/workflows/build-capability.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to include environment variables for Supabase configuration. These changes ensure that the build process has access to the necessary credentials for interacting with Supabase.

Workflow updates:

* [`.github/workflows/build-capability.yml`](diffhunk://#diff-fd569839c16f451253536f994948901bd6507edd54b26a0237249899cf7b2502R14-R16): Added `SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_URL` as environment variables using GitHub Secrets.