### PR TITLE
refactor: update nginx config and docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,43 @@
 services:
     web:
         build: .
-        ports:
-            - "3000:3000"
+        container_name: "web_app"
+        expose:
+            - "3000"
         environment:
             - NODE_ENV=production
         env_file:
             - .env
+        networks:
+            - webnet
+    nginx:
+        image: nginx:stable-alpine
+        container_name: "nginx_proxy"
+        depends_on:
+            - web
+        ports:
+            - "80:80"
+            - "443:443"
+        volumes:
+            - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+            - certbot-etc:/etc/letsencrypt
+            - certbot-var:/var/lib/letsencrypt
+        networks:
+            - webnet
+    certbot:
+        image: certbot/certbot
+        container_name: "certbot"
+        volumes:
+            - certbot-etc:/etc/letsencrypt
+            - certbot-var:/var/lib/letsencrypt
+        entrypoint: >
+            sh -c "trap exit TERM; while :; do
+            certbot renew --webroot -w /var/lib/letsencrypt;
+            sleep 12h & wait $${!}; done"
+
+volumes:
+    certbot-etc:
+    certbot-var:
+
+networks:
+    webnet:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,9 +40,5 @@ services:
               sleep 12h & wait $${!}; 
             done"
 
-volumes:
-    certbot-etc:
-    certbot-var:
-
 networks:
     webnet:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
     web:
         build: .
         container_name: "web_app"
+        restart: always
         expose:
             - "3000"
         environment:
@@ -13,6 +14,7 @@ services:
     nginx:
         image: nginx:stable-alpine
         container_name: "nginx_proxy"
+        restart: always
         depends_on:
             - web
         ports:
@@ -20,20 +22,22 @@ services:
             - "443:443"
         volumes:
             - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-            - certbot-etc:/etc/letsencrypt
-            - certbot-var:/var/lib/letsencrypt
+            - ./data/certbot/www:/var/lib/letsencrypt
+            - ./data/certbot/conf:/etc/letsencrypt
         networks:
             - webnet
     certbot:
         image: certbot/certbot
         container_name: "certbot"
         volumes:
-            - certbot-etc:/etc/letsencrypt
-            - certbot-var:/var/lib/letsencrypt
+            - ./data/certbot/www:/var/lib/letsencrypt
+            - ./data/certbot/conf:/etc/letsencrypt
         entrypoint: >
-            sh -c "trap exit TERM; while :; do
-            certbot renew --webroot -w /var/lib/letsencrypt;
-            sleep 12h & wait $${!}; done"
+            sh -c "trap exit TERM;
+            while :; do
+              certbot renew --webroot -w /var/lib/letsencrypt;
+              sleep 12h & wait $${!}; 
+            done"
 
 volumes:
     certbot-etc:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,24 +1,34 @@
+# Redirect HTTP -> HTTPS
+server {
+    listen 80;
+    server_name staging.transpo.id;
+
+    location /.well-known/acme-challenge/ {
+        root /var/lib/letsencrypt;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS server block
 server {
     listen 443 ssl;
     server_name staging.transpo.id;
 
     ssl_certificate /etc/letsencrypt/live/staging.transpo.id/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/staging.transpo.id/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/staging.transpo.id/chain.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     location / {
         proxy_pass http://web:3000;
-        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
-}
-
-server {
-    listen 80;
-    server_name staging.transpo.id;
-    return 301 https://$host$request_uri;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,9 +1,9 @@
 server {
     listen 443 ssl;
-    server_name stagging.transpo.id;
+    server_name staging.transpo.id;
 
-    ssl_certificate /etc/letsencrypt/live/stagging.transpo.id/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/stagging.transpo.id/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/staging.transpo.id/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/staging.transpo.id/privkey.pem;
 
     location / {
         proxy_pass http://web:3000;
@@ -19,6 +19,6 @@ server {
 
 server {
     listen 80;
-    server_name stagging.transpo.id;
+    server_name staging.transpo.id;
     return 301 https://$host$request_uri;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,24 @@
+server {
+    listen 443 ssl;
+    server_name stagging.transpo.id;
+
+    ssl_certificate /etc/letsencrypt/live/stagging.transpo.id/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/stagging.transpo.id/privkey.pem;
+
+    location / {
+        proxy_pass http://web:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
+server {
+    listen 80;
+    server_name stagging.transpo.id;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
This pull request sets up production-ready HTTPS support and reverse proxying for the web application using Docker Compose and Nginx. It introduces new service definitions for Nginx and Certbot, updates the web service configuration, and adds an Nginx configuration file to handle SSL termination and automatic certificate renewal.

**Infrastructure and Service Configuration:**

* Added `nginx` and `certbot` services to `docker-compose.yaml`, enabling SSL termination and automated certificate renewal for HTTPS.
* Updated the `web` service in `docker-compose.yaml` to use a named container, always restart, expose port 3000 internally, and connect to a shared network for proxying.

**Security and Networking:**

* Created a new `nginx.conf` file that redirects HTTP traffic to HTTPS and configures Nginx to proxy HTTPS requests to the web service, using certificates managed by Certbot.
* Set up Docker volumes and networks in `docker-compose.yaml` to persist SSL certificates and enable communication between services.